### PR TITLE
define missing "SAVE_IRPACKER_TREE" in initialize-eeprom  #1

### DIFF
--- a/firmware/t/initialize-eeprom/src/env.h
+++ b/firmware/t/initialize-eeprom/src/env.h
@@ -19,5 +19,6 @@
 
 // we're going to use saveLimitedAPPassword
 #define FACTORY_CHECKER 1
+#define SAVE_IRPACKER_TREE 1
 
 #endif


### PR DESCRIPTION
#1 のbugfixです

firmware/t/initialize-eepromの`irpacker_save`関数を動かす為に、`SAVE_IRPACKER_TREE`をdefineしました。
