### PR TITLE
Turn ON blue LED when wifi connected

### DIFF
--- a/firmware/src/IRKit/IRKit.ino
+++ b/firmware/src/IRKit/IRKit.ino
@@ -195,8 +195,6 @@ void process_commands() {
             gs.close(command);
             break;
         case COMMAND_START_POLLING:
-            color.setLedColor( 0, 0, 1, false ); // blue: ready
-
             irkit_httpclient_start_polling( 0 );
             break;
         default:
@@ -284,6 +282,7 @@ void connect() {
         else if (keys.isValid()) {
             IR_state( IR_IDLE );
             ring_put( &commands, COMMAND_START_POLLING );
+            color.setLedColor( 0, 0, 1, false ); // blue: ready
         }
     }
     else {


### PR DESCRIPTION
## 現状

青色LEDの点灯設定が、COMMAND_START_POLLINGが発行された後 irkit_httpclient_start_polling関数の呼び出し前に行われていた
## 変更点

青色LEDの点灯設定を、WiFiが接続された時にのみ行います。
これにより、Internet APIから赤外線発射した時も、ローカルでの赤外線発射と同様に青色LEDが点滅するようになります。

COMMAND_START_POLLINGが発行される毎に青色に指定されていた為、Internet APIでは青色LEDの点滅が上書きキャンセルされ、赤外線がでているのかどうか判別が難しかったです。
