### PR TITLE
Options for LED behavior and offline mode

### DIFF
--- a/firmware/src/IRKit/FullColorLed.cpp
+++ b/firmware/src/IRKit/FullColorLed.cpp
@@ -23,38 +23,31 @@ FullColorLed::FullColorLed(int pinR, int pinG, int pinB) :
     pinG_(pinG),
     pinB_(pinB),
     blinkOn_(0),
-    isBlinking_(false),
+    blinkMode_(ALWAYS_ON),
     blink_timer_(TIMER_OFF)
 {
 }
 
-void FullColorLed::setLedColor(bool colorR, bool colorG, bool colorB) {
-    setLedColor(colorR, colorG, colorB, false);
-}
-
-void FullColorLed::setLedColor(bool colorR, bool colorG, bool colorB, bool blink) {
+void FullColorLed::setLedColor(bool colorR, bool colorG, bool colorB, LightMode lightMode, uint8_t blinkTimeout) {
     colorR_      = colorR;
     colorG_      = colorG;
     colorB_      = colorB;
-    isBlinking_  = blink;
+    blinkMode_   = lightMode;
 
     blink_timer_ = TIMER_OFF;
-}
-
-void FullColorLed::setLedColor(bool colorR, bool colorG, bool colorB, bool blink, uint8_t blink_timeout) {
-    setLedColor( colorR, colorG, colorB, blink );
-
-    TIMER_START(blink_timer_, blink_timeout);
+    if (blinkTimeout > 0) {
+        TIMER_START(blink_timer_, blinkTimeout);
+    }
 }
 
 void FullColorLed::off() {
-    setLedColor( 0, 0, 0, false );
+    setLedColor( 0, 0, 0 );
 }
 
 void FullColorLed::onTimer() {
     blinkOn_ = ! blinkOn_;
 
-    if ( blinkOn_ || ! isBlinking_ ) {
+    if ( blinkOn_ || (blinkMode_ == ALWAYS_ON) ) {
         // not blinking = always on
         digitalWrite(pinR_, colorR_);
         digitalWrite(pinG_, colorG_);
@@ -69,6 +62,10 @@ void FullColorLed::onTimer() {
     TIMER_TICK(blink_timer_);
     if (TIMER_FIRED(blink_timer_)) {
         TIMER_STOP(blink_timer_);
-        isBlinking_ = false;
+        if (blinkMode_ == BLINK_THEN_OFF) {
+            off();
+        } else if (blinkMode_ == BLINK_THEN_ON) {
+            blinkMode_ = ALWAYS_ON;
+        }
     }
 }

--- a/firmware/src/IRKit/FullColorLed.cpp
+++ b/firmware/src/IRKit/FullColorLed.cpp
@@ -17,11 +17,9 @@
 #include <Arduino.h>
 #include "FullColorLed.h"
 #include "timer.h"
+#include "pins.h"
 
-FullColorLed::FullColorLed(int pinR, int pinG, int pinB) :
-    pinR_(pinR),
-    pinG_(pinG),
-    pinB_(pinB),
+FullColorLed::FullColorLed() :
     blinkOn_(0),
     blinkMode_(ALWAYS_ON),
     blink_timer_(TIMER_OFF)
@@ -49,14 +47,14 @@ void FullColorLed::onTimer() {
 
     if ( blinkOn_ || (blinkMode_ == ALWAYS_ON) ) {
         // not blinking = always on
-        digitalWrite(pinR_, colorR_);
-        digitalWrite(pinG_, colorG_);
-        digitalWrite(pinB_, colorB_);
+        digitalWrite(FULLCOLOR_LED_R, colorR_);
+        digitalWrite(FULLCOLOR_LED_G, colorG_);
+        digitalWrite(FULLCOLOR_LED_B, colorB_);
     }
     else {
-        digitalWrite(pinR_, LOW);
-        digitalWrite(pinG_, LOW);
-        digitalWrite(pinB_, LOW);
+        digitalWrite(FULLCOLOR_LED_R, LOW);
+        digitalWrite(FULLCOLOR_LED_G, LOW);
+        digitalWrite(FULLCOLOR_LED_B, LOW);
     }
 
     TIMER_TICK(blink_timer_);

--- a/firmware/src/IRKit/FullColorLed.h
+++ b/firmware/src/IRKit/FullColorLed.h
@@ -20,11 +20,27 @@
 class FullColorLed
 {
 public:
+
+    // The different modes for lighting the LED
+    typedef enum  {
+        ALWAYS_ON       = 0,    // LED stays always on.
+        BLINK_THEN_ON   = 1,    // LED blinks, then stays on.
+        BLINK_THEN_OFF  = 2     // LED blinks, then turns off.
+    } LightMode;
+
     FullColorLed(int pinR, int pinG, int pinB);
-    void setLedColor(bool colorR, bool colorG, bool colorB);
-    void setLedColor(bool colorR, bool colorG, bool colorB, bool blink);
-    void setLedColor(bool colorR, bool colorG, bool colorB, bool blink, uint8_t blink_timeout);
+
+    // Lights-up the LED with a specific color, with optional blinking parameters.
+    void setLedColor(
+            bool colorR,
+            bool colorG,
+            bool colorB,
+            LightMode lightMode = ALWAYS_ON,
+            uint8_t blinkTimeout = 0);
+
+    // Turns-off the LED
     void off();
+
     void onTimer();
 
 private:
@@ -34,7 +50,7 @@ private:
     bool colorR_;
     bool colorG_;
     bool colorB_;
-    bool isBlinking_; // defaults to off
+    LightMode blinkMode_; // defaults to ALWAYS_ON
     volatile bool blinkOn_; // altered inside timer ISR
     volatile uint8_t blink_timer_;
 };

--- a/firmware/src/IRKit/FullColorLed.h
+++ b/firmware/src/IRKit/FullColorLed.h
@@ -28,7 +28,7 @@ public:
         BLINK_THEN_OFF  = 2     // LED blinks, then turns off.
     } LightMode;
 
-    FullColorLed(int pinR, int pinG, int pinB);
+    FullColorLed();
 
     // Lights-up the LED with a specific color, with optional blinking parameters.
     void setLedColor(
@@ -44,9 +44,6 @@ public:
     void onTimer();
 
 private:
-    int pinR_;
-    int pinG_;
-    int pinB_;
     bool colorR_;
     bool colorG_;
     bool colorB_;

--- a/firmware/src/IRKit/IRKit.ino
+++ b/firmware/src/IRKit/IRKit.ino
@@ -36,7 +36,7 @@
 static struct long_press_button_state_t long_press_button_state;
 static volatile uint8_t reconnect_timer = TIMER_OFF;
 static char commands_data[COMMAND_QUEUE_SIZE];
-static FullColorLed color( FULLCOLOR_LED_R, FULLCOLOR_LED_G, FULLCOLOR_LED_B );
+static FullColorLed color;
 
 struct RingBuffer commands;
 GSwifi gs(&Serial1X);

--- a/firmware/src/IRKit/IRKitHTTPHandler.cpp
+++ b/firmware/src/IRKit/IRKitHTTPHandler.cpp
@@ -23,6 +23,7 @@
 #include "timer.h"
 #include "commands.h"
 #include "log.h"
+#include "config.h"
 
 extern GSwifi gs;
 extern Keys keys;
@@ -480,6 +481,12 @@ void irkit_http_on_timer() {
 }
 
 void irkit_http_loop() {
+
+    if (!config::useCloudControl) {
+        // Cloud control is currently disabled. No polling loop.
+        return;
+    }
+
     // long poll
     if (TIMER_FIRED(polling_timer)) {
         TIMER_STOP(polling_timer);

--- a/firmware/src/IRKit/config.h
+++ b/firmware/src/IRKit/config.h
@@ -1,0 +1,46 @@
+/*
+ Copyright (C) 2013-2014 Masakazu Ohtsuka
+  
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 2 of the License, or
+ (at your option) any later version.
+  
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+  
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+/*
+ * Exposes some general options for your IRKit device.
+ */
+namespace config {
+
+    // Different modes for the LED feedback.
+    typedef enum {
+        LED_VERBOSE    = 0, // LED almost always-on to indicate the device status.
+        LED_QUIET      = 1, // LED on during setup and blinks when receiving/sending commands. Off when the device is idle.
+        LED_SETUP_ONLY = 2, // LED on only during the setup, then always-off.
+        LED_OFF        = 3  // /!\ This disables the LED completely.
+    } LedFeedbackProfile;
+
+    // Defines what kind of LED profile you want.
+    const LedFeedbackProfile ledFeedback = LED_QUIET;
+
+    // Enables/disables cloud-control through the "deviceapi.getirkit.com" server.
+    // If you use your IRKit device exclusively over your LAN, you can disable
+    // this option: the device won't send regular polling requests to the cloud server.
+    // This also lets you setup your device without internet access (no need for a valid device key).
+    const bool useCloudControl = true;
+
+}
+
+#endif // __CONFIG_H__
+
+


### PR DESCRIPTION
If you're interested, I added a `config.h` to setup some option at compile time. 
- `ledFeedback`: define how the LED should behave (always on, always off, only when transmitting IR...). 
  I like to be able to disable the LED, to keep the room dark at night.
  _Set to `LED_VERBOSE` to keep the same behavior as the current `master` branch._  
- `useCloudControl`: for people who use their device only over the LAN. This disables DNS, device id check, and regular request polling to the cloud servers.
  _Set to `true` to keep the same behavior as the current `master` branch._
